### PR TITLE
mac: Set minimum OS requirement in plist

### DIFF
--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -2,6 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
+        <key>LSMinimumSystemVersion</key>
+    	<string>10.15.7</string>
+
         <key>CFBundleExecutable</key>
         <string>VencordInstaller</string>
 

--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
     <dict>
         <key>LSMinimumSystemVersion</key>
-    	<string>10.15.7</string>
+    	<string>10.15</string>
 
         <key>CFBundleExecutable</key>
         <string>VencordInstaller</string>


### PR DESCRIPTION
Change plist requirements to allow installing on macOS Catalina and later