### PR TITLE
Switch to `Return` instead

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -6,7 +6,7 @@ $isAdmin = [bool]([Security.Principal.WindowsIdentity]::GetCurrent().Groups -mat
 
 if ($isAdmin) {
 	Write-Output "Do not run me as Administrator! Exiting..."
-	Break
+	Return
 }
 
 
@@ -24,10 +24,10 @@ $choice = Read-Host "Please choose by typing a number or Q"
 switch ($choice) {
 	1 { $link = $DOWNLOAD_GUI }
 	2 { $link = $DOWNLOAD_CLI }
-	q { Break }
+	q { Return }
 	default {
 		Write-Output "Invalid choice $choice. Exiting..."
-		Break
+		Return
 	}	
 }
 
@@ -57,10 +57,10 @@ if ($choice -eq 2) {
 		3 { $flag = "-uninstall" }
 		4 { $flag = "-uninstall-openasar" }
 		5 { $flag = "-update" }
-		q { Break }
+		q { Return }
 		default {
 			Write-Output "Invalid choice $choice. Exiting..."
-			Break
+			Return
 		}
 	}
 }


### PR DESCRIPTION
I've realised that this is a better keyword than `Break` since it has less contextual meanings and is guaranteed to return control back to the shell.