### PR TITLE
Add cli support for MacOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,12 +81,16 @@ jobs:
       - name: Install Go dependencies
         run: go get -v
 
-      - name: Build
+      - name: Build GUI
         run: CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -tags static -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstaller
+
+      - name: Build CLI
+        run: CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -tags "static cli" -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstaller-cli
 
       - name: Update executable
         run: |
           chmod +x VencordInstaller
+          chmod +x VencordInstaller-cli
 
       - name: Generate MacOS bundle
         run: |
@@ -95,7 +99,7 @@ jobs:
           cp macos/Info.plist VencordInstaller.app/Contents/Info.plist
           mv VencordInstaller VencordInstaller.app/Contents/MacOS/VencordInstaller
           cp macos/icon.icns VencordInstaller.app/Contents/Resources/icon.icns
-          zip -r VencordInstaller.MacOS.zip VencordInstaller.app
+          zip -r VencordInstaller.MacOS.zip VencordInstaller.app VencordInstaller-cli
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/README.md
+++ b/README.md
@@ -64,3 +64,8 @@ go build --tags cli
 
 You might want to pass some flags to this command to get a better build.
 See [the GitHub workflow](https://github.com/Vendicated/VencordInstaller/blob/main/.github/workflows/release.yml) for what flags I pass or if you want more precise instructions
+
+### Notes
+
+#### MacOS
+In order to use cli in mac os you need to grant Terminal Full Disk Accesss in *System Settings > Privacy & Security > Full Disk Access*


### PR DESCRIPTION
Add cli version in release for MacOS.
Tested in MacOS Sequoia 15.0.1.
Terminal App must be granted full disk access in *System Settings > Privacy & Security > Full Disk Access*

Solves #128 