### PR TITLE
Fix variable name in GUI

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -627,13 +627,13 @@ func loop() {
 			g.Dummy(0, 20),
 			g.Style().SetFontSize(20).To(
 				g.Row(
-					g.Label(Ternary(IsDevInstall, "Dev Install: ", "Vencord will be downloaded to: ")+VencordAsarPath),
+					g.Label(Ternary(IsDevInstall, "Dev Install: ", "Vencord will be downloaded to: ")+VencordDirectory),
 					g.Style().
 						SetColor(g.StyleColorButton, DiscordBlue).
 						SetStyle(g.StyleVarFramePadding, 4, 4).
 						To(
 							g.Button("Open Directory").OnClick(func() {
-								g.OpenURL("file://" + path.Dir(VencordAsarPath))
+								g.OpenURL("file://" + path.Dir(VencordDirectory))
 							}),
 						),
 				),


### PR DESCRIPTION
At some point the name of the variable `VencordAsarPath` seems to have been changed to `VencordDirectory` in one file and then not changed where it was referenced in `gui.go`, making it impossible to compile the GUI.