### PR TITLE
add MacOS CLI (again)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           chmod +x VencordInstallerCli-linux
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v5
         with:
           name: VencordInstaller-linux
           path: |
@@ -85,7 +85,7 @@ jobs:
         run: CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -tags static -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstaller
 
       - name: Build CLI
-        run: CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -tags "static cli" -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstallerMacOSCli
+        run: CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -tags "static cli" -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstallerCli-MacOS
 
       - name: Update executable
         run: |
@@ -101,12 +101,12 @@ jobs:
           zip -r VencordInstaller.MacOS.zip VencordInstaller.app
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v5
         with:
           name: VencordInstaller-macos
           path: |
             VencordInstaller.MacOS.zip
-            VencordInstallerMacOSCli
+            VencordInstallerCli-MacOS
 
 
   build-windows:
@@ -164,7 +164,7 @@ jobs:
           CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -v -tags "static cli" -ldflags "-s -w -extldflags=-static -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstallerCli.exe
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v5
         with:
           name: VencordInstaller-windows
           path: |
@@ -206,5 +206,5 @@ jobs:
           files: |
             linux/VencordInstallerCli-linux
             macos/VencordInstaller.MacOS.zip
-            macos/VencordInstallerMacOSCli
+            macos/VencordInstallerCli-MacOS
             windows/VencordInstalle*.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,11 @@ jobs:
       - name: Install Go dependencies
         run: go get -v
 
-      - name: Build
+      - name: Build GUI
         run: CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -tags static -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstaller
+
+      - name: Build CLI
+        run: CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -tags "static cli" -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstallerMacOSCli
 
       - name: Update executable
         run: |
@@ -101,7 +104,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: VencordInstaller-macos
-          path: VencordInstaller.MacOS.zip
+          path: |
+            VencordInstaller.MacOS.zip
+            VencordInstallerMacOSCli
 
 
   build-windows:
@@ -201,4 +206,5 @@ jobs:
           files: |
             linux/VencordInstallerCli-linux
             macos/VencordInstaller.MacOS.zip
+            macos/VencordInstallerMacOSCli
             windows/VencordInstalle*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vencordinstaller
 *.exe
 *.syso
 *.old
+.DS_Store


### PR DESCRIPTION
closes #128

a copy of #144 (credit where due), but unlike that PR and like the windows version, the CLI is carried to the final release where it is uploaded separately

i also bumped `actions/upload-artifact` since v3 is no longer supported, as well as added .DS_Store to the .gitignore because MacOS is a pain