### PR TITLE
Add cache for custom discord instance

### DIFF
--- a/find_discord_darwin.go
+++ b/find_discord_darwin.go
@@ -50,15 +50,26 @@ func FindDiscords() []any {
 		"/Applications",
 		path.Join(os.Getenv("HOME"), "Applications"),
 	}
+	
+	handleDiscordDir := func(p string, branch string) {
+		if discord := ParseDiscord(p, branch); discord != nil {
+			Log.Debug("Found Discord install at ", p)
+			discords = append(discords, discord)
+		}
+	}
+
 	for branch, dirname := range macosNames {
 		for _, base := range bases {
 			p := path.Join(base, dirname)
-			if discord := ParseDiscord(p, branch); discord != nil {
-				Log.Debug("Found Discord Install at", p)
-				discords = append(discords, discord)
-			}
+			handleDiscordDir(p, branch)
 		}
 	}
+
+	discordCustomDir := os.Getenv("VENCORD_DISCORD_DIR")
+	if discordCustomDir != "" {
+		handleDiscordDir(discordCustomDir, "custom")
+	}
+
 	return discords
 }
 

--- a/find_discord_linux.go
+++ b/find_discord_linux.go
@@ -62,7 +62,7 @@ func init() {
 	}
 }
 
-func ParseDiscord(p, _ string) *DiscordInstall {
+func ParseDiscord(p, branch string) *DiscordInstall {
 	name := path.Base(p)
 
 	needsFlatpakResolve := strings.Contains(p, "/flatpak/") && !strings.Contains(p, "/current/active/files/")
@@ -90,9 +90,13 @@ func ParseDiscord(p, _ string) *DiscordInstall {
 		return nil
 	}
 
+	if branch == "" {
+		branch = GetBranch(name)
+	}
+
 	return &DiscordInstall{
 		path:             p,
-		branch:           GetBranch(name),
+		branch:           branch,
 		appPath:          app,
 		isPatched:        isPatched,
 		isFlatpak:        needsFlatpakResolve,
@@ -102,6 +106,14 @@ func ParseDiscord(p, _ string) *DiscordInstall {
 
 func FindDiscords() []any {
 	var discords []any
+	
+	handleDiscordDir := func(p string, branch string) {
+		if discord := ParseDiscord(p, branch); discord != nil {
+			Log.Debug("Found Discord install at ", p)
+			discords = append(discords, discord)
+		}
+	}
+
 	for _, dir := range DiscordDirs {
 		children, err := os.ReadDir(dir)
 		if err != nil {
@@ -118,11 +130,13 @@ func FindDiscords() []any {
 			}
 
 			discordDir := path.Join(dir, name)
-			if discord := ParseDiscord(discordDir, ""); discord != nil {
-				Log.Debug("Found Discord install at ", discordDir)
-				discords = append(discords, discord)
-			}
+			handleDiscordDir(discordDir, "")
 		}
+	}
+
+	discordCustomDir := os.Getenv("VENCORD_DISCORD_DIR")
+	if discordCustomDir != "" {
+		handleDiscordDir(discordCustomDir, "custom")
 	}
 
 	return discords

--- a/find_discord_windows.go
+++ b/find_discord_windows.go
@@ -77,13 +77,23 @@ func FindDiscords() []any {
 		return discords
 	}
 
-	for branch, dirname := range windowsNames {
-		p := path.Join(appData, dirname)
+	handleDiscordDir := func(p string, branch string) {
 		if discord := ParseDiscord(p, branch); discord != nil {
 			Log.Debug("Found Discord install at ", p)
 			discords = append(discords, discord)
 		}
 	}
+
+	for branch, dirname := range windowsNames {
+		p := path.Join(appData, dirname)
+		handleDiscordDir(p, branch)
+	}
+		
+	discordCustomDir := os.Getenv("VENCORD_DISCORD_DIR")
+	if discordCustomDir != "" {
+		handleDiscordDir(discordCustomDir, "custom")
+	}
+
 	return discords
 }
 


### PR DESCRIPTION
This PR adds cache for a discord instance that was previously saved via the `VENCORD_DISCORD_DIR` environment variable.
That way you dont need to search for the same instance over and over if you have it in a custom location.

I could've phrased it better. By cache I mean the custom instance is added to the list of discord instances that gets shown in the "main menu".