### PR TITLE
Build a universal macOS binary and modernize the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@
 
 name: Release
 on:
+  workflow_dispatch:
   push:
     tags:
       - v*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
             VencordInstallerCli-linux
 
   build-mac-amd64:
-    runs-on: macos-latest
+    runs-on: macos-26
 
     steps:
       - name: Install Go
@@ -95,7 +95,7 @@ jobs:
           path: VencordInstaller
 
   build-mac-arm64:
-    runs-on: macos-latest
+    runs-on: macos-26-intel
 
     steps:
       - name: Install Go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,8 @@ jobs:
             VencordInstallerCli-linux
 
 
-  build-mac:
-    runs-on: macos-latest
+  build-mac-amd64:
+    runs-on: macos-13
 
     steps:
       - name: Install Go
@@ -86,6 +86,88 @@ jobs:
 
       - name: Update executable
         run: |
+          chmod +x VencordInstaller
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: VencordInstaller-macos-amd64-bin
+          path: VencordInstaller
+
+
+  build-mac-arm64:
+    runs-on: macos-14
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+
+      - id: go-cache-paths
+        run: |
+          echo "go_build=$(go env GOCACHE)" >> $GITHUB_ENV
+          echo "go_mod=$(go env GOMODCACHE)" >> $GITHUB_ENV
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/Library/Caches/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-go-
+            ${{ runner.os }}-go-
+
+      - name: Install dependencies
+        run: brew install pkg-config sdl2
+
+      - name: Install Go dependencies
+        run: go get -v
+
+      - name: Build
+        run: CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -v -tags static -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstaller
+
+      - name: Update executable
+        run: |
+          chmod +x VencordInstaller
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: VencordInstaller-macos-arm64-bin
+          path: VencordInstaller
+
+
+  build-mac-universal:
+    runs-on: macos-14
+    needs: [build-mac-amd64, build-mac-arm64]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: VencordInstaller-macos-amd64-bin
+          path: macos-amd64
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: VencordInstaller-macos-arm64-bin
+          path: macos-arm64
+
+      - name: Create universal binary
+        run: |
+          chmod +x macos-amd64/VencordInstaller
+          chmod +x macos-arm64/VencordInstaller
+          lipo -create \
+            macos-amd64/VencordInstaller \
+            macos-arm64/VencordInstaller \
+            -output VencordInstaller
           chmod +x VencordInstaller
 
       - name: Generate MacOS bundle
@@ -169,7 +251,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [build-linux, build-mac, build-windows]
+    needs: [build-linux, build-mac-universal, build-windows]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           chmod +x VencordInstallerCli-linux
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: VencordInstaller-linux
           path: |
@@ -89,7 +89,7 @@ jobs:
           chmod +x VencordInstaller
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: VencordInstaller-macos-amd64-bin
           path: VencordInstaller
@@ -135,7 +135,7 @@ jobs:
           chmod +x VencordInstaller
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: VencordInstaller-macos-arm64-bin
           path: VencordInstaller
@@ -148,12 +148,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: VencordInstaller-macos-amd64-bin
           path: macos-amd64
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: VencordInstaller-macos-arm64-bin
           path: macos-arm64
@@ -178,7 +178,7 @@ jobs:
           zip -r VencordInstaller.MacOS.zip VencordInstaller.app
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: VencordInstaller-macos
           path: VencordInstaller.MacOS.zip
@@ -238,7 +238,7 @@ jobs:
           CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -v -tags "static cli" -ldflags "-s -w -extldflags=-static -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstallerCli.exe
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: VencordInstaller-windows
           path: |
@@ -253,17 +253,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: VencordInstaller-linux
           path: linux
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: VencordInstaller-macos
           path: macos
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: VencordInstaller-windows
           path: windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-20.04 # hopefully older glibc for better compatibility on systems like debian bullseye
+    runs-on: ubuntu-22.04 # explicit supported runner with broad Linux compatibility
 
     steps:
       - name: Install Go
@@ -267,6 +267,19 @@ jobs:
         with:
           name: VencordInstaller-windows
           path: windows
+
+      - name: Remove stale macOS arch-specific release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null | while read -r asset; do
+            case "$asset" in
+              *macos*amd64*|*macos*arm64*|*darwin*amd64*|*darwin*arm64*|*apple-silicon*|*intel*|VencordInstaller-amd64|VencordInstaller-arm64|VencordInstaller-darwin-amd64|VencordInstaller-darwin-arm64)
+                gh release delete-asset "$TAG" "$asset" --yes
+                ;;
+            esac
+          done
 
       - name: Create the release
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 # v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,18 @@
 name: Release
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        description: The release tag to build and publish
+        required: true
   push:
     tags:
       - v*
 
 env:
   FORCE_COLOR: true
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
 jobs:
   build-linux:
@@ -36,7 +42,7 @@ jobs:
         run: go get -v
 
       - name: Build Cli
-        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -tags "static cli" -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstallerCli-linux
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -tags "static cli" -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ env.RELEASE_TAG }}'" -o VencordInstallerCli-linux
 
       - name: Update executable
         run: |
@@ -82,7 +88,7 @@ jobs:
         run: go get -v
 
       - name: Build
-        run: CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -tags static -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstaller
+        run: CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -tags static -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ env.RELEASE_TAG }}'" -o VencordInstaller
 
       - name: Update executable
         run: |
@@ -128,7 +134,7 @@ jobs:
         run: go get -v
 
       - name: Build
-        run: CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -v -tags static -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstaller
+        run: CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -v -tags static -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ env.RELEASE_TAG }}'" -o VencordInstaller
 
       - name: Update executable
         run: |
@@ -228,14 +234,14 @@ jobs:
           export GOROOT=/mingw64/lib/go
           export GOPATH=/mingw64
           go-winres make --product-version "git-tag"
-          CGO_ENABLED=1 GOOS=windows GOARCH=amd64 go build -v -tags static -ldflags "-s -w -H=windowsgui -extldflags=-static -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstaller.exe
+          CGO_ENABLED=1 GOOS=windows GOARCH=amd64 go build -v -tags static -ldflags "-s -w -H=windowsgui -extldflags=-static -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ env.RELEASE_TAG }}'" -o VencordInstaller.exe
 
       - name: Build i386 Cli
         shell: msys2 {0}
         run: |
           export GOROOT=/mingw64/lib/go
           export GOPATH=/mingw64
-          CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -v -tags "static cli" -ldflags "-s -w -extldflags=-static -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstallerCli.exe
+          CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -v -tags "static cli" -ldflags "-s -w -extldflags=-static -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ env.RELEASE_TAG }}'" -o VencordInstallerCli.exe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -271,7 +277,7 @@ jobs:
       - name: Remove stale macOS arch-specific release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ env.RELEASE_TAG }}
         run: |
           gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null | while read -r asset; do
             case "$asset" in
@@ -286,7 +292,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: ${{ github.ref_name }}
+          tag_name: ${{ env.RELEASE_TAG }}
+          target_commitish: ${{ github.sha }}
+          name: ${{ env.RELEASE_TAG }}
           prerelease: false
           draft: false
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,8 @@ jobs:
           path: |
             VencordInstallerCli-linux
 
-
   build-mac-amd64:
-    runs-on: macos-13
+    runs-on: macos-latest
 
     steps:
       - name: Install Go
@@ -95,9 +94,8 @@ jobs:
           name: VencordInstaller-macos-amd64-bin
           path: VencordInstaller
 
-
   build-mac-arm64:
-    runs-on: macos-14
+    runs-on: macos-latest
 
     steps:
       - name: Install Go
@@ -142,7 +140,6 @@ jobs:
           name: VencordInstaller-macos-arm64-bin
           path: VencordInstaller
 
-
   build-mac-universal:
     runs-on: macos-14
     needs: [build-mac-amd64, build-mac-arm64]
@@ -185,7 +182,6 @@ jobs:
         with:
           name: VencordInstaller-macos
           path: VencordInstaller.MacOS.zip
-
 
   build-windows:
     runs-on: windows-latest
@@ -248,7 +244,6 @@ jobs:
           path: |
             VencordInstaller.exe
             VencordInstallerCli.exe
-
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Mark workspace as a safe Git directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - uses: actions/cache@v3
         with:
           path: |
@@ -39,7 +42,7 @@ jobs:
         run: go get -v
 
       - name: Build Cli
-        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -tags "static cli" -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ env.RELEASE_TAG }}'" -o VencordInstallerCli-linux
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildvcs=false -v -tags "static cli" -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ env.RELEASE_TAG }}'" -o VencordInstallerCli-linux
 
       - name: Update executable
         run: |
@@ -85,7 +88,7 @@ jobs:
         run: go get -v
 
       - name: Build
-        run: CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -tags static -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ env.RELEASE_TAG }}'" -o VencordInstaller
+        run: CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -buildvcs=false -v -tags static -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ env.RELEASE_TAG }}'" -o VencordInstaller
 
       - name: Update executable
         run: |
@@ -131,7 +134,7 @@ jobs:
         run: go get -v
 
       - name: Build
-        run: CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -v -tags static -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ env.RELEASE_TAG }}'" -o VencordInstaller
+        run: CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -buildvcs=false -v -tags static -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ env.RELEASE_TAG }}'" -o VencordInstaller
 
       - name: Update executable
         run: |
@@ -231,14 +234,14 @@ jobs:
           export GOROOT=/mingw64/lib/go
           export GOPATH=/mingw64
           go-winres make --product-version "git-tag"
-          CGO_ENABLED=1 GOOS=windows GOARCH=amd64 go build -v -tags static -ldflags "-s -w -H=windowsgui -extldflags=-static -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ env.RELEASE_TAG }}'" -o VencordInstaller.exe
+          CGO_ENABLED=1 GOOS=windows GOARCH=amd64 go build -buildvcs=false -v -tags static -ldflags "-s -w -H=windowsgui -extldflags=-static -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ env.RELEASE_TAG }}'" -o VencordInstaller.exe
 
       - name: Build i386 Cli
         shell: msys2 {0}
         run: |
           export GOROOT=/mingw64/lib/go
           export GOPATH=/mingw64
-          CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -v -tags "static cli" -ldflags "-s -w -extldflags=-static -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ env.RELEASE_TAG }}'" -o VencordInstallerCli.exe
+          CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -buildvcs=false -v -tags "static cli" -ldflags "-s -w -extldflags=-static -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ env.RELEASE_TAG }}'" -o VencordInstallerCli.exe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
             VencordInstallerCli-linux
 
   build-mac-amd64:
-    runs-on: macos-26
+    runs-on: macos-26-intel
 
     steps:
       - name: Install Go
@@ -101,7 +101,7 @@ jobs:
           path: VencordInstaller
 
   build-mac-arm64:
-    runs-on: macos-26-intel
+    runs-on: macos-26
 
     steps:
       - name: Install Go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,10 @@ env:
 jobs:
   build-linux:
     runs-on: ubuntu-22.04 # explicit supported runner with broad Linux compatibility
+    container:
+      image: golang:1.20-bullseye
 
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.20"
-
       - name: Checkout code
         uses: actions/checkout@v3
 


### PR DESCRIPTION
### Summary

This PR updates the release pipeline to create a native Apple Silicon macOS build while keeping Intel support, then merges both into a single universal macOS binary for release. [Universal macOS binaries](https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary) run natively on Intel and Apple Silicon systems.

It also cleans up a few workflow issues that came up along the way. It adds a workflow_dispatch trigger for manual releases, migrates artifact actions from deprecated v3 to v4 (required for build), and moves the Linux runner from ubuntu-20.04 to ubuntu-22.04 (required for build).

### What Changed

- Split the macOS build into separate Intel and Apple Silicon jobs
- Merge the two macOS binaries with lipo
- Package and publish only the universal VencordInstaller.MacOS.zip
- Keep the per-arch binaries as workflow artifacts only, for the merge step

### Why

The currently published macOS binary requires Rosetta 2, which isn't optimal. Apple plans to remove Rosetta 2 in 2027, and developers should not be using it, especially since macOS Tahoe is the last release to support Mac computers with Intel chips.