### PR TITLE
feat: build native Apple Silicon version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: VencordInstaller-macos-arm64
-          path: macos-arm64
+          path: macos
 
       - uses: actions/download-artifact@v3
         with:
@@ -215,5 +215,5 @@ jobs:
           files: |
             linux/VencordInstallerCli-linux
             macos/VencordInstaller.MacOS.zip
-            macos-arm64/VencordInstaller.MacOS-AppleSilicon.zip
+            macos/VencordInstaller.MacOS-AppleSilicon.zip
             windows/VencordInstalle*.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,20 @@ jobs:
           path: |
             VencordInstallerCli-linux
 
-
   build-mac:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: macos-15-intel
+            artifact_name: VencordInstaller-macos
+            zip_name: VencordInstaller.MacOS.zip
+          - arch: arm64
+            runner: macos-latest
+            artifact_name: VencordInstaller-macos-arm64
+            zip_name: VencordInstaller.MacOS-AppleSilicon.zip
 
     steps:
       - name: Install Go
@@ -71,9 +82,9 @@ jobs:
           path: |
             ~/Library/Caches/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-${{ matrix.arch }}-go-
 
       - name: Install dependencies
         run: brew install pkg-config sdl2
@@ -82,7 +93,7 @@ jobs:
         run: go get -v
 
       - name: Build
-        run: CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -tags static -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstaller
+        run: CGO_ENABLED=1 GOOS=darwin GOARCH=${{ matrix.arch }} go build -v -tags static -ldflags "-s -w -X 'vencordinstaller/buildinfo.InstallerGitHash=$(git rev-parse --short HEAD)' -X 'vencordinstaller/buildinfo.InstallerTag=${{ github.ref_name }}'" -o VencordInstaller
 
       - name: Update executable
         run: |
@@ -95,14 +106,13 @@ jobs:
           cp macos/Info.plist VencordInstaller.app/Contents/Info.plist
           mv VencordInstaller VencordInstaller.app/Contents/MacOS/VencordInstaller
           cp macos/icon.icns VencordInstaller.app/Contents/Resources/icon.icns
-          zip -r VencordInstaller.MacOS.zip VencordInstaller.app
+          zip -r ${{ matrix.zip_name }} VencordInstaller.app
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: VencordInstaller-macos
-          path: VencordInstaller.MacOS.zip
-
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.zip_name }}
 
   build-windows:
     runs-on: windows-latest
@@ -166,7 +176,6 @@ jobs:
             VencordInstaller.exe
             VencordInstallerCli.exe
 
-
   release:
     runs-on: ubuntu-latest
     needs: [build-linux, build-mac, build-windows]
@@ -187,6 +196,11 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
+          name: VencordInstaller-macos-arm64
+          path: macos-arm64
+
+      - uses: actions/download-artifact@v3
+        with:
           name: VencordInstaller-windows
           path: windows
 
@@ -201,4 +215,5 @@ jobs:
           files: |
             linux/VencordInstallerCli-linux
             macos/VencordInstaller.MacOS.zip
+            macos-arm64/VencordInstaller.MacOS-AppleSilicon.zip
             windows/VencordInstalle*.exe


### PR DESCRIPTION
## Problem

The macOS release build currently only produces an Intel `amd64` binary. On Apple Silicon Macs, that requires Rosetta and can trigger macOS compatibility warnings about Intel-only apps losing support in macOS 28 (source: https://support.apple.com/en-us/102527).

## Proposed solution

Update the macOS release workflow to build both Intel and Apple Silicon variants using a GitHub Actions matrix. The existing Intel build remains available for older Macs, while a new native `arm64` Apple Silicon zip is generated and uploaded with the release. The matrix keeps both builds in a single shared job so the packaging process stays consistent and avoids duplicating nearly identical workflow steps.

## Caveats

The public website and any other distribution channels (e.g. Homebrew?) will need to be updated with the new build links.