### PR TITLE
Support Discord installations in ~/.config directories on Linux

### DIFF
--- a/find_discord_linux.go
+++ b/find_discord_linux.go
@@ -65,11 +65,17 @@ func init() {
 func ParseDiscord(p, _ string) *DiscordInstall {
 	name := path.Base(p)
 
+	if strings.HasPrefix(name, "app-") {
+		parent := path.Base(path.Dir(p))
+		if parent != "." && parent != "/" {
+			name = parent
+		}
+	}
+
 	needsFlatpakResolve := strings.Contains(p, "/flatpak/") && !strings.Contains(p, "/current/active/files/")
 	if needsFlatpakResolve {
 		discordName := strings.ToLower(name[len("com.discordapp."):])
-		if discordName != "discord" { //
-			// DiscordCanary -> discord-canary
+		if discordName != "discord" {
 			discordName = discordName[:7] + "-" + discordName[7:]
 		}
 		p = path.Join(p, "current/active/files", discordName)
@@ -80,9 +86,9 @@ func ParseDiscord(p, _ string) *DiscordInstall {
 
 	isPatched, isSystemElectron := false, false
 
-	if ExistsFile(resources) { // normal install
+	if ExistsFile(resources) {
 		isPatched = ExistsFile(path.Join(resources, "_app.asar"))
-	} else if ExistsFile(path.Join(p, "app.asar")) { // System electron doesn't have resources folder
+	} else if ExistsFile(path.Join(p, "app.asar")) {
 		isSystemElectron = true
 		isPatched = ExistsFile(path.Join(p, "_app.asar.unpacked"))
 	} else {

--- a/find_discord_linux.go
+++ b/find_discord_linux.go
@@ -100,6 +100,70 @@ func ParseDiscord(p, _ string) *DiscordInstall {
 	}
 }
 
+func FindLatestAppDir(base string) string {
+	children, err := os.ReadDir(base)
+	if err != nil {
+		return ""
+	}
+
+	var latest string
+	var latestVer []int
+
+	for _, child := range children {
+		name := child.Name()
+		if !child.IsDir() || !strings.HasPrefix(name, "app-") {
+			continue
+		}
+
+		verStr := strings.TrimPrefix(name, "app-")
+		parts := strings.Split(verStr, ".")
+		var ver []int
+
+		for _, p := range parts {
+			n, err := strconv.Atoi(p)
+			if err != nil {
+				n = 0
+			}
+			ver = append(ver, n)
+		}
+
+		if latest == "" || CompareAppVersions(ver, latestVer) > 0 {
+			latest = name
+			latestVer = ver
+		}
+	}
+
+	if latest == "" {
+		return ""
+	}
+
+	return path.Join(base, latest)
+}
+
+func CompareAppVersions(a, b []int) int {
+	l := len(a)
+	if len(b) > l {
+		l = len(b)
+	}
+
+	for i := 0; i < l; i++ {
+		ai, bi := 0, 0
+		if i < len(a) {
+			ai = a[i]
+		}
+		if i < len(b) {
+			bi = b[i]
+		}
+		if ai > bi {
+			return 1
+		}
+		if ai < bi {
+			return -1
+		}
+	}
+	return 0
+}
+
 func FindDiscords() []any {
 	var discords []any
 	for _, dir := range DiscordDirs {
@@ -120,6 +184,28 @@ func FindDiscords() []any {
 			discordDir := path.Join(dir, name)
 			if discord := ParseDiscord(discordDir, ""); discord != nil {
 				Log.Debug("Found Discord install at ", discordDir)
+				discords = append(discords, discord)
+			}
+		}
+	}
+
+	configBase := path.Join(Home, ".config")
+	configDirs, err := os.ReadDir(configBase)
+	if err == nil {
+		for _, child := range configDirs {
+			name := child.Name()
+			if !child.IsDir() || !SliceContains(LinuxDiscordNames, name) {
+				continue
+			}
+
+			base := path.Join(configBase, name)
+			appDir := FindLatestAppDir(base)
+			if appDir == "" {
+				continue
+			}
+
+			if discord := ParseDiscord(appDir, ""); discord != nil {
+				Log.Debug("Found Discord install at ", appDir)
 				discords = append(discords, discord)
 			}
 		}


### PR DESCRIPTION
An update to fix the known issue where new discord installations are installed in the ~/.config directory on Linux. (https://discord.com/channels/1015060230222131221/1497300840636092516)

e.g.
`/home/theo/.config/discord/app-1.0.136/`
`/home/theo/.config/discordcanary/app-1.0.968/`

<img width="623" height="107" alt="image" src="https://github.com/user-attachments/assets/12087ceb-a40b-4ff1-aa69-1a97afeca3b9" />